### PR TITLE
Reduce LOC for ledge json requests

### DIFF
--- a/Core/src/main/java/com/hawolt/client/resources/ledge/AbstractLedgeEndpoint.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/AbstractLedgeEndpoint.java
@@ -8,6 +8,8 @@ import com.hawolt.version.IVersionSupplier;
 import com.hawolt.virtual.leagueclient.authentication.Session;
 import com.hawolt.virtual.leagueclient.client.Authentication;
 import com.hawolt.virtual.leagueclient.userinfo.UserInformation;
+import okhttp3.HttpUrl;
+import okhttp3.Request;
 
 /**
  * Created: 19/01/2023 16:44
@@ -46,5 +48,21 @@ public abstract class AbstractLedgeEndpoint extends UndocumentedEndpoint {
                 leagueVersionSupplier.getVersionValue(platform, "LeagueClientUxRender.exe"),
                 rcp()
         );
+    }
+
+    public Request.Builder jsonRequest(HttpUrl url) {
+        return internaljsonRequest(new Request.Builder()
+                .url(url));
+    }
+    public Request.Builder jsonRequest(String uri) {
+        return internaljsonRequest(new Request.Builder()
+                .url(uri));
+    }
+
+    private Request.Builder internaljsonRequest(Request.Builder builder) {
+        return builder
+                .addHeader("Authorization", auth())
+                .addHeader("User-Agent", agent())
+                .addHeader("Accept", "application/json");
     }
 }

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/AbstractLedgeEndpoint.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/AbstractLedgeEndpoint.java
@@ -51,15 +51,15 @@ public abstract class AbstractLedgeEndpoint extends UndocumentedEndpoint {
     }
 
     public Request.Builder jsonRequest(HttpUrl url) {
-        return internaljsonRequest(new Request.Builder()
+        return internalJsonRequest(new Request.Builder()
                 .url(url));
     }
     public Request.Builder jsonRequest(String uri) {
-        return internaljsonRequest(new Request.Builder()
+        return internalJsonRequest(new Request.Builder()
                 .url(uri));
     }
 
-    private Request.Builder internaljsonRequest(Request.Builder builder) {
+    private Request.Builder internalJsonRequest(Request.Builder builder) {
         return builder
                 .addHeader("Authorization", auth())
                 .addHeader("User-Agent", agent())

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/inventory/InventoryServiceLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/inventory/InventoryServiceLedge.java
@@ -32,13 +32,7 @@ public class InventoryServiceLedge extends AbstractLedgeEndpoint {
                 .addQueryParameter("inventoryTypes", "CHAMPION_SKIN")
                 .addQueryParameter("accountId", String.valueOf(client.getVirtualRiotClient().getRiotClientUser().getDataUserId()))
                 .build();
-        Request request = new Request.Builder()
-                .url(url)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        Request request = jsonRequest(url).get().build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
             try (ResponseBody body = response.body()) {
@@ -56,13 +50,7 @@ public class InventoryServiceLedge extends AbstractLedgeEndpoint {
                 name(),
                 version()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        Request request = jsonRequest(uri).get().build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
             try (ResponseBody body = response.body()) {

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/leagues/LeagueLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/leagues/LeagueLedge.java
@@ -27,13 +27,7 @@ public class LeagueLedge extends AbstractLedgeEndpoint {
                 name(),
                 version()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        Request request = jsonRequest(uri).get().build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
             try (ResponseBody body = response.body()) {
@@ -51,13 +45,7 @@ public class LeagueLedge extends AbstractLedgeEndpoint {
                 version(),
                 puuid
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        Request request = jsonRequest(uri).get().build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
             try (ResponseBody body = response.body()) {

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/loot/LootLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/loot/LootLedge.java
@@ -62,11 +62,7 @@ public class LootLedge extends AbstractLedgeEndpoint {
             array.put(upgrade);
         }
         object.put("lootNameRefIds", array);
-        Request request = new Request.Builder()
-                .url(url)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(url)
                 .post(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -94,13 +90,7 @@ public class LootLedge extends AbstractLedgeEndpoint {
                 .addQueryParameter("lastRecipeUpdate", timestamp)
                 .addQueryParameter("lastQueryUpdate", timestamp)
                 .build();
-        Request request = new Request.Builder()
-                .url(url)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .get()
-                .build();
+        Request request = jsonRequest(url).get().build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
             try (ResponseBody body = response.body()) {

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/parties/PartiesLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/parties/PartiesLedge.java
@@ -163,12 +163,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
         object.put("maxPartySize", maxPartySize);
         object.put("maxTeamSize", maxTeamSize);
         object.put("queueId", queueId);
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .put(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
+        Request request = jsonRequest(uri).put(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
@@ -187,12 +182,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
                 version(),
                 partyId
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
-                .put(RequestBody.create(type.toString(), Constant.APPLICATION_JSON))
+        Request request = jsonRequest(uri).put(RequestBody.create(type.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
         try (Response response = call.execute()) {
@@ -212,11 +202,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
                 partyId,
                 userInformation.getSub()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .put(RequestBody.create(role.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -238,11 +224,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
                 userInformation.getSub(),
                 action.name().toLowerCase() + "Action"
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .post(RequestBody.create(new byte[0], Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -271,11 +253,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
         array.put(first.name());
         array.put(second.name());
         object.put("positionPref", array);
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .put(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -296,11 +274,7 @@ public class PartiesLedge extends AbstractLedgeEndpoint {
                 current.getFirstPartyId(),
                 userInformation.getSub()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .put(RequestBody.create("true", Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/perks/PerksLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/perks/PerksLedge.java
@@ -54,11 +54,7 @@ public class PerksLedge extends AbstractLedgeEndpoint {
                 self.getSummonerId()
         );
 
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .post(RequestBody.create(escape(runes.toString()), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/store/StoreLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/store/StoreLedge.java
@@ -32,11 +32,7 @@ public class StoreLedge extends AbstractLedgeEndpoint {
                 "1",
                 client.getVirtualLeagueClientInstance().getPlatform()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .get()
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -64,11 +60,7 @@ public class StoreLedge extends AbstractLedgeEndpoint {
         object.put("inventoryType", type.name());
         object.put("itemId", itemId);
         array.put(object);
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .post(RequestBody.create(array.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -85,11 +77,7 @@ public class StoreLedge extends AbstractLedgeEndpoint {
                 name(),
                 "2"
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .get()
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/summoner/SummonerLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/summoner/SummonerLedge.java
@@ -49,11 +49,7 @@ public class SummonerLedge extends AbstractLedgeEndpoint {
     }
 
     public Summoner resolveSummoner(String uri) throws IOException {
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .get()
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -74,11 +70,7 @@ public class SummonerLedge extends AbstractLedgeEndpoint {
                 platform.name().toLowerCase(),
                 userInformation.getSub()
         );
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .get()
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -101,11 +93,7 @@ public class SummonerLedge extends AbstractLedgeEndpoint {
                 .addPathSegment("validatename")
                 .addQueryParameter("summonerName", name)
                 .build();
-        Request request = new Request.Builder()
-                .url(url)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(url)
                 .get()
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);
@@ -131,11 +119,7 @@ public class SummonerLedge extends AbstractLedgeEndpoint {
                 .build();
         JSONObject object = new JSONObject();
         object.put("summonerName", name);
-        Request request = new Request.Builder()
-                .url(url)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(url)
                 .post(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);

--- a/Core/src/main/java/com/hawolt/client/resources/ledge/teambuilder/TeamBuilderLedge.java
+++ b/Core/src/main/java/com/hawolt/client/resources/ledge/teambuilder/TeamBuilderLedge.java
@@ -40,11 +40,7 @@ public class TeamBuilderLedge extends AbstractLedgeEndpoint {
         object.put("initialSpellIds", new JSONArray().put(14).put(4));
         object.put("lastSelectedSkinIdByChampionId", new JSONObject());
         object.put("simplifiedInventoryJwt", client.getLedge().getInventoryService().getInventoryToken());
-        Request request = new Request.Builder()
-                .url(uri)
-                .addHeader("Authorization", auth())
-                .addHeader("User-Agent", agent())
-                .addHeader("Accept", "application/json")
+        Request request = jsonRequest(uri)
                 .post(RequestBody.create(object.toString(), Constant.APPLICATION_JSON))
                 .build();
         Call call = OkHttp3Client.perform(request, gateway);


### PR DESCRIPTION
This PR reduces LOC/code duplication by replacing the creation of each RequestBuilder with the headers `Authorization`, `User-Agent` and `Accept` with a method call to a newly created method [jsonRequest](https://github.com/FluentCoding/custom-league-client/blob/87f5b8277dfbef226cc7ca74d98c9c9201021e42/Core/src/main/java/com/hawolt/client/resources/ledge/AbstractLedgeEndpoint.java#L53-L67) in the base class AbstractLedgeEndpoint, available to each ledge class.